### PR TITLE
Always build dynamic library

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,2 +1,3 @@
+set(BUILD_SHARED_LIBS ON)
 set(CTEST_PROJECT_NAME "PoC-Detect")
 set(MEMORYCHECK_COMMAND_OPTIONS  "--tool=memcheck --show-reachable=yes --track-fds=yes --num-callers=32 --memcheck:leak-check=yes --memcheck:leak-resolution=high --error-exitcode=1")


### PR DESCRIPTION
On some systems (Ubuntu 15.10 ﻿Wily) cmake will build static library by default. This option force cmake to build .so dynamic library.