### PR TITLE
perf.c: help fix

### DIFF
--- a/perf/perf.c
+++ b/perf/perf.c
@@ -95,7 +95,7 @@ perf_usage(const char *progname)
             "\t-P   List available parsers and exit\n"
             "\t-p   Parser to use (default is sqli)\n"
             "\t-e   Echo input strings\n"
-            "\t     (verbose=1: attacks only, verbose=1: all)\n"
+            "\t     (verbose=0: attacks only, verbose>0: all)\n"
             "\t-r   Show small report for each input string\n"
             "\t-n   Show total number of strings and attacks\n"
             , progname);


### PR DESCRIPTION
Help was definitely inaccurate regarding echo. Here's proof that shows how it actually works:
$ echo "selec"|./build/perf/perf -e
$ echo "select"|./build/perf/perf -e
select
(i.e. if verbose=0 then only input strings with attacks are echoed)
$ echo "selec"|./build/perf/perf -ev
selec
$ echo "select"|./build/perf/perf -ev
select
(i.e. if verbose>0 then all input strings are echoed)