### PR TITLE
test/detect_unit.c: small fix

### DIFF
--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -88,6 +88,7 @@ main(void)
     if ((sum = CU_get_run_summary()) == NULL ||
         sum->nSuitesFailed || sum->nTestsFailed || sum->nAssertsFailed) {
 
+        CU_cleanup_registry();
         return (EXIT_FAILURE);
     }
     CU_cleanup_registry();


### PR DESCRIPTION
There wasn't proper cleanup if any error was occured. Manual says that cleanup should always be called at the end of testing: http://cunit.sourceforge.net/doc/test_registry.html#cleanup