### PR TITLE
detect_buf.h: fixed "double free or corruption" error

### DIFF
--- a/include/detect_buf.h
+++ b/include/detect_buf.h
@@ -56,8 +56,10 @@ detect_buf_add_char(struct detect_buf *buf, unsigned char ch)
         new_allocated = 0;
     if (buf->data.len == new_allocated)
         return (EOVERFLOW);
-    if ((str = realloc(buf->data.str, new_allocated)) == NULL)
+    if ((str = realloc(buf->data.str, new_allocated)) == NULL) {
+        buf->data.str = NULL;
         return (ENOMEM);
+        };
     buf->data.str = str;
     buf->allocated = new_allocated;
     buf->data.str[buf->data.len++] = ch;


### PR DESCRIPTION
This error have occured if perf tried to process an alphanumeric string longer than 32 characters with sqli or pt parser (e.g. echo "000000000000000000000000000000000" | ./perf).

What specifically happened:
1. 32 symbols was added by detect_buf_add_char() successfully.
2. Program entered in detect_buf_add_char() in 33-rd time.
3. if (buf->data.len != buf->allocated)  {...}
This if() failed, because (buf->data.len == 32) and (buf->allocated == 32).
4. new_allocated = buf->allocated ? buf->allocated * 2 : buf->minsiz;
So new_allocated == 64, because buf->allocated == 32.
5. if (buf->maxsiz >= 0 && new_allocated > buf->maxsiz) new_allocated = 0;
This if() succeded, because (buf->maxsiz == 32) and (64 > 32).
6. if (buf->data.len == new_allocated) {...}
This if() failed, because 32 != 64.
7. if ((str = realloc(buf->data.str, new_allocated)) == NULL) return (ENOMEM);
We call realloc(buf->data.str, 0), meaning that we free buf->data.str: "if size is equal to zero, and ptr is not NULL, then the call [realloc] is equivalent to free(ptr)" (http://linux.die.net/man/3/realloc).
8. Then the detect_buf_deinit() function is called, trying to free non-NULL buf->data.str again!
if (buf->data.str != NULL) free(buf->data.str);

This patch changes such behavior: buf->data.str is assigned to NULL on step 7, so it wouldn't be double-freed on step 8. Additionaly, it fixes same problem that occured if perf tried to process an alphanumeric string with spaces longer than 32 characters with sqli or pt parser (e.g. echo "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0" | ./perf). An execution path is different in this case though.