### PR TITLE
Processing null byte in string literal

### DIFF
--- a/lib/detect_re2c.c
+++ b/lib/detect_re2c.c
@@ -219,7 +219,6 @@ detect_re2c_yyfill(
         unsigned zero_fill_size = need - (*end - ctx->pos);
         memset((void *)*end, 0, zero_fill_size);
         (*end) += zero_fill_size;
-        ctx->tmp_data_siz += zero_fill_size;
         return (0);
     }
 }

--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -146,11 +146,18 @@ sqli_get_token(
           YYSETSTATE(-1);
           RET_DATA(DATA, ctx, arg);
       }
-      <INSTRING,SQUOTE,DQUOTE,BQUOTE> [\x00] => INITIAL {
-          DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)--;
-          arg->data.flags |= SQLI_DATA_NOEND;
-          YYSETSTATE(-1);
-          RET_DATA(DATA, ctx, arg);
+      <INSTRING,SQUOTE,DQUOTE,BQUOTE> [\x00] {
+          if (ctx->lexer.re2c.fin && ctx->lexer.re2c.tmp_data_in_use &&
+              ctx->lexer.re2c.pos >= ctx->lexer.re2c.tmp_data + ctx->lexer.re2c.tmp_data_siz) {
+              YYSETCONDITION(sqli_INITIAL);
+              DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)--;
+              arg->data.flags |= SQLI_DATA_NOEND;
+              YYSETSTATE(-1);
+              RET_DATA(DATA, ctx, arg);
+          }
+          detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
+          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          goto yy0;
       }
       <INSTRING,SQUOTE,DQUOTE,BQUOTE> . {
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -445,6 +445,21 @@ Tsqli_execute(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_nul_in_str(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("1\0' ^ '"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 
 int
 main(void)
@@ -477,6 +492,7 @@ main(void)
         {"into_outfile", Tsqli_into_outfile},
         {"declare", Tsqli_declare},
         {"execute", Tsqli_execute},
+        {"nul_in_str", Tsqli_nul_in_str},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Null bytes may be present in string literals.
In this case, it is impossible to determine the end of a string literal by the null byte, and a condition is required to determine the end of the data in the buffer, complete lexical analysis and not extend the buffer further using a placeholder.
To do this, we keep `ctx-> tmp_data_siz` equal to the actual length of the data in the buffer (excluding the placeholders for lexical analysis).