### PR TITLE
 Processing of injections in the table name 

### DIFF
--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -543,7 +543,7 @@ after_exp_cont_op_noexpr:
 
 after_exp_cont_op:
         expr after_exp_cont_op_noexpr
-        | after_exp_cont_op_noexpr
+        | where_opt after_exp_cont_op_noexpr
         ;
 
 after_exp_cont:

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -58,6 +58,21 @@ Tsqli_rce(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_inj_in_table_name(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("1' where 1=1"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 int
 main(void)
 {
@@ -68,6 +83,7 @@ main(void)
     CU_TestInfo sqli_tests[] = {
         {"simplest", Tsqli_simplest},
         {"rce", Tsqli_rce},
+        {"inj_in_tabel_name", Tsqli_inj_in_table_name},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
The `WHERE` clause may appear at the beginning of the SQL injection.
For example, table name SQL injection: `table_name where 1=1`.