### PR TITLE
TOP clause

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -474,6 +474,12 @@ sqli_get_token(
       <INITIAL> '&&' {
           KEYNAME_SET_RET(ctx, arg, AND, SQLI_KEY_INSTR);
       }
+      <INITIAL> 'TOP'/key_end {
+          KEYNAME_SET_RET(ctx, arg, TOP, SQLI_KEY_INSTR);
+      }
+      <INITIAL> 'PERCENT'/key_end {
+          KEYNAME_SET_RET(ctx, arg, PERCENT, SQLI_KEY_INSTR);
+      }
       <INITIAL> opchar => OPERATOR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -37,7 +37,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token <data> TOK_FROM TOK_INTO TOK_WHERE
 %token <data> TOK_AS TOK_ON TOK_USING
 %token <data> TOK_UNION TOK_INTERSECT TOK_EXCEPT TOK_ALL
-%token <data> TOK_ORDER TOK_GROUP TOK_BY TOK_HAVING
+%token <data> TOK_ORDER TOK_GROUP TOK_BY TOK_HAVING TOK_TOP TOK_PERCENT
 %token <data> TOK_CROSS TOK_FULL TOK_INNER TOK_LEFT TOK_RIGHT
 %token <data> TOK_LIMIT TOK_OFFSET
 %token <data> TOK_NATURAL TOK_JOIN
@@ -495,7 +495,24 @@ select_parens:
         | '('[u1] select_parens ')'[u2] {YYUSE($u1); YYUSE($u2);}
         ;
 
-select:   TOK_SELECT[tk] select_args into_opt from_opt
+percent_opt:
+        | TOK_PERCENT[tk] {
+                sqli_store_data(ctx, &$tk);
+        }
+
+top_opt:
+        | TOK_TOP[tk] data_name[data] percent_opt {
+            sqli_store_data(ctx, &$tk);
+            sqli_store_data(ctx, &$data);
+        }
+        | TOK_TOP[tk] '('[u1] expr ')'[u2] percent_opt {
+            sqli_store_data(ctx, &$tk);
+            YYUSE($u1);
+            YYUSE($u2);
+        }
+        ;
+
+select:   TOK_SELECT[tk] top_opt select_args into_opt from_opt
           where_opt select_after_where {
             sqli_store_data(ctx, &$tk);
         }

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -58,6 +58,21 @@ Tsqli_rce(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_top(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("SELECT TOP 5 * FROM table_name"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 int
 main(void)
 {
@@ -68,6 +83,7 @@ main(void)
     CU_TestInfo sqli_tests[] = {
         {"simplest", Tsqli_simplest},
         {"rce", Tsqli_rce},
+        {"top", Tsqli_top},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Adding SELECT TOP clause in grammar

`TOP (expression) [PERCENT]` (Transact-SQL)
`TOP n [PERCENT]` (Access)