### PR TITLE
Vertical tab and no-break space as whitespace

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -95,7 +95,7 @@ sqli_get_token(
       re2c:condprefix      = sqli_;
       re2c:condenumprefix  = sqli_;
 
-      whitespace = [ \t\b\r\n\f];
+      whitespace = [ \t\v\b\r\n\f\xA0]|[\xC2][\xA0];
       self = [,\.()\[\];];
       opchar = [~!^&|?%:+\-*/<>=];
       opchar_nocomment = [~!^&|?%+<>=];

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -58,6 +58,26 @@ Tsqli_rce(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_whitespace(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("1\vor\v1"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("1\u00A0or\u00A01"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 int
 main(void)
 {
@@ -68,6 +88,7 @@ main(void)
     CU_TestInfo sqli_tests[] = {
         {"simplest", Tsqli_simplest},
         {"rce", Tsqli_rce},
+        {"whitespace", Tsqli_whitespace},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Adding vertical tab and no-break space (0xC2 0xA0) as whitespace. Also in injections may appear 0xA0