### PR TITLE
Bit-Value Literals

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -191,6 +191,24 @@ sqli_get_token(
           YYSETSTATE(-1);
           RET_DATA(DATA, ctx, arg);
       }
+      <BITVALUE, QBITVALUE> [0-1] {
+          if (!detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
+              DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+              goto yy0;
+          } else {
+              detect_buf_deinit(&ctx->lexer.buf);
+              RET(ctx, TOK_ERROR);
+          }
+      }
+      <QBITVALUE> ['] => INITIAL {
+          YYSETSTATE(-1);
+          RET_DATA(DATA, ctx, arg);
+      }
+      <BITVALUE, QBITVALUE> [^] => INITIAL {
+          DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)--;
+          YYSETSTATE(-1);
+          RET_DATA(DATA, ctx, arg);
+      }
       <VAR> [0-9a-zA-Z_@$] {
           if (!detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
               DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
@@ -566,6 +584,20 @@ sqli_get_token(
           detect_buf_add_char(&ctx->lexer.buf, 'x');
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
           goto sqli_HEXNUMBER;
+      }
+      <INITIAL> ("0b"|'b')[0-1] => BITVALUE {
+          detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, 256);
+          detect_buf_add_char(&ctx->lexer.buf, '0');
+          detect_buf_add_char(&ctx->lexer.buf, 'b');
+          detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
+          goto sqli_BITVALUE;
+      }
+      <INITIAL> ("0b'"|'b\'')[0-1] => QBITVALUE {
+          detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, 256);
+          detect_buf_add_char(&ctx->lexer.buf, '0');
+          detect_buf_add_char(&ctx->lexer.buf, 'b');
+          detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
+          goto sqli_QBITVALUE;
       }
       <INITIAL> [0-9] => NUMBER {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, 256);

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -299,6 +299,33 @@ Tsqli_create_func(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_bit_num(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("0b01UNION SELECT 1"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("B01UNION ALL SELECT 1"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("0b'01'UNION SELECT 1"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("B'01' UNION ALL SELECT 1"), true), 0);
+}
+
 int
 main(void)
 {
@@ -322,6 +349,7 @@ main(void)
         {"func", Tsqli_func},
         {"var_start_with_dollar", Tsqli_var_start_with_dollar},
         {"create_func", Tsqli_create_func},
+        {"bit_num", Tsqli_bit_num},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Bit-value literals are written using `b'val'` or `0bval` notation. val is a binary value written using zeros and ones. Lettercase of any leading `b` does not matter. A leading `0b` is case sensitive and cannot be written as `0B` (MySQL)