### PR TITLE
JOIN w/o USING or ON clause

### DIFF
--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -388,7 +388,7 @@ natural_opt:
         ;
 
 join_qual:
-        TOK_USING[tk] '('[u1] name_list ')'[u2] {
+        | TOK_USING[tk] '('[u1] name_list ')'[u2] {
             sqli_store_data(ctx, &$tk);
             YYUSE($u1);
             YYUSE($u2);

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -299,6 +299,22 @@ Tsqli_create_func(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_join_wo_join_qual(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+      detect_add_data(detect,
+                      STR_LEN_ARGS("SELECT * FROM (SELECT * FROM (SELECT 1) \
+                                    as t JOIN (SELECT 2)b)a"), true), 0);
+  CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+  CU_ASSERT_EQUAL(detect_stop(detect), 0);
+  CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
 int
 main(void)
 {
@@ -322,6 +338,7 @@ main(void)
         {"func", Tsqli_func},
         {"var_start_with_dollar", Tsqli_var_start_with_dollar},
         {"create_func", Tsqli_create_func},
+        {"join_wo_join_qual", Tsqli_join_wo_join_qual},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
JOIN can be without USING or ON clause.
Example: MySQL