### PR TITLE
EXECUTE statement

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -537,6 +537,9 @@ sqli_get_token(
       <INITIAL> 'STRICT'/key_end {
           KEYNAME_SET_RET(ctx, arg, STRICT, SQLI_KEY_INSTR);
       }
+      <INITIAL> 'EXEC'/key_end {
+          KEYNAME_SET_RET(ctx, arg, EXECUTE, SQLI_KEY_WRITE|SQLI_KEY_INSTR);
+      }
       <INITIAL> opchar => OPERATOR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -13,7 +13,7 @@
 static const unsigned char selfsyms[] = {
     SSYM('.'), SSYM(','), SSYM('('), SSYM(')'),
     SSYM('*'), SSYM('['), SSYM(']'),
-    SSYM(';'),
+    SSYM(';'), SSYM('='),
 };
 
 int
@@ -96,8 +96,8 @@ sqli_get_token(
       re2c:condenumprefix  = sqli_;
 
       whitespace = [ \t\v\b\r\n\f\xA0]|[\xC2][\xA0];
-      self = [,\.()\[\];];
-      opchar = [~!^&|?%:+\-*/<>=];
+      self = [,\.()\[\];=];
+      opchar = [~!^&|?%:+\-*/<>];
       opchar_nocomment = [~!^&|?%+<>=];
       key_end = [^a-zA-Z0-9_];
 

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -116,6 +116,7 @@ sql_no_parens:
         | waitfor_delay
         | func
         | create_function
+        | execute
         | command error {
             sqli_store_data(ctx, &$command);
             yyclearin;
@@ -578,8 +579,28 @@ create_function: TOK_CREATE[tk1] or_replace_opt TOK_FUNCTION[tk2] func
         }
         ;
 
+param: data_name[value] {
+            sqli_store_data(ctx, &$value);
+        }
+        | data_name[name] '='[u1] data_name[value] {
+            sqli_store_data(ctx, &$name);
+            YYUSE($u1);
+            sqli_store_data(ctx, &$value);
+        }
+        ;
+
+param_list: param
+        | param ','[u1] param_list {
+            YYUSE($u1);
+        }
+        ;
+execute:
+        TOK_EXECUTE[tk] func_name param_list {
+            sqli_store_data(ctx, &$tk);
+        }
+        ;
+
 command:  TOK_INSERT
-        | TOK_EXECUTE
         | TOK_DELETE
         | TOK_ATTACH
         | TOK_DROP

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -31,7 +31,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token TOK_START_RCE
 %token <data> TOK_DISTINCT TOK_VARIADIC
 %token <data> TOK_DATA TOK_NAME TOK_OPERATOR
-%token <data> '.' ',' '(' ')' '*' '[' ']' ';'
+%token <data> '.' ',' '(' ')' '*' '[' ']' ';' '='
 %token <data> TOK_OR TOK_AND TOK_IS TOK_NOT TOK_DIV
               TOK_MOD TOK_XOR TOK_REGEXP
               TOK_BINARY TOK_SOUNDS TOK_OUTFILE
@@ -321,6 +321,7 @@ operator: TOK_OR
         | TOK_INTO
         | TOK_OUTFILE
         | '*'
+        | '='
         ;
 
 select_distinct_opt:

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -291,6 +291,7 @@ Tsqli_create_func(void)
     CU_ASSERT_EQUAL(detect_start(detect), 0);
     CU_ASSERT_EQUAL(
         detect_add_data(detect,
+
                         STR_LEN_ARGS("1; CREATE OR REPLACE FUNCTION SLEEP(int) \
                                       RETURNS int AS '/lib/libc.so.6','sleep'  \
                                       language 'C' STRICT"), true), 0);
@@ -298,6 +299,24 @@ Tsqli_create_func(void)
     CU_ASSERT_EQUAL(detect_stop(detect), 0);
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
+
+static void
+Tsqli_executee(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect,
+                        STR_LEN_ARGS("EXEC master.dbo.xp_cmdshell 'cmd'"),
+                        true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 
 int
 main(void)
@@ -322,6 +341,7 @@ main(void)
         {"func", Tsqli_func},
         {"var_start_with_dollar", Tsqli_var_start_with_dollar},
         {"create_func", Tsqli_create_func},
+        {"executee", Tsqli_executee},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Adding `EXECUTE` as statement in grammar
```
[ { EXEC | EXECUTE } ]  
    {
      { module_name | @module_name_var }   
        [ [ @parameter = ] { value   
                           | @variable 
                           }  
        ]  
      [ ,...n ]  
    } 
```
(Transact-SQL)

```
EXECUTE stmt_name
    [USING @var_name [, @var_name] ...]
```
(MySQL)