### PR TITLE
Character set for string literal and COLLATE clause

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -580,6 +580,9 @@ sqli_get_token(
       <INITIAL> 'TABLE'/key_end {
           KEYNAME_SET_RET(ctx, arg, TABLE, SQLI_KEY_INSTR);
       }
+      <INITIAL> 'COLLATE'/key_end {
+          KEYNAME_SET_RET(ctx, arg, COLLATE, SQLI_KEY_INSTR);
+      }
       <INITIAL> opchar => OPERATOR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -585,7 +585,7 @@ sqli_get_token(
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
           goto sqli_OPERATOR;
       }
-      <INITIAL> ['] => SQUOTE {
+      <INITIAL> [']|'_latin'[17]whitespace*[']|'n'[']|'x'[']|'_utf8'whitespace*['] => SQUOTE {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           goto sqli_SQUOTE;
       }

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -34,7 +34,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token <data> '.' ',' '(' ')' '*' '[' ']' ';' '='
 %token <data> TOK_OR TOK_AND TOK_IS TOK_NOT TOK_DIV
               TOK_MOD TOK_XOR TOK_REGEXP
-              TOK_BINARY TOK_SOUNDS TOK_OUTFILE
+              TOK_BINARY TOK_SOUNDS TOK_OUTFILE TOK_COLLATE
 %token <data> TOK_FOR
 %token <data> TOK_FROM TOK_INTO TOK_WHERE
 %token <data> TOK_AS TOK_ON TOK_USING
@@ -334,6 +334,7 @@ operator: TOK_OR
         | TOK_SOUNDS
         | TOK_INTO
         | TOK_OUTFILE
+        | TOK_COLLATE
         | '*'
         | '='
         ;

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -480,6 +480,24 @@ Tsqli_drop(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_string(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS(
+            "SELECT _latin1 'str' COLLATE latin1_german2_ci a, n'str' b, "
+            "x'str' c, _utf8'str' d"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
+
 int
 main(void)
 {
@@ -513,6 +531,7 @@ main(void)
         {"execute", Tsqli_execute},
         {"nul_in_str", Tsqli_nul_in_str},
         {"drop", Tsqli_drop},
+        {"string", Tsqli_string},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
A character string literal may have an optional character set introducer and COLLATE clause
```
[_charset_name]'string' [COLLATE collation_name]
```
(MySQL, Oracle)