### PR TITLE
CALL statement

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -601,6 +601,9 @@ sqli_get_token(
       <INITIAL> 'QUICK'/key_end {
           KEYNAME_SET_RET(ctx, arg, QUICK, SQLI_KEY_INSTR);
       }
+      <INITIAL> 'CALL'/key_end {
+          KEYNAME_SET_RET(ctx, arg, CALL, SQLI_KEY_INSTR);
+      }
       <INITIAL> opchar => OPERATOR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -61,6 +61,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token <data> TOK_TABLE
 %token <data> TOK_USE
 %token <data> TOK_IGNORE TOK_LOW_PRIORITY TOK_QUICK
+%token <data> TOK_CALL
 %token TOK_FUNC
 %token TOK_ERROR
 
@@ -130,6 +131,7 @@ sql_no_parens:
         | drop
         | use
         | _delete
+        | call
         | command error {
             sqli_store_data(ctx, &$command);
             yyclearin;
@@ -730,6 +732,11 @@ _delete:  TOK_DELETE[tk1] delete_modifier_opt TOK_FROM[key] from_list where_opt 
         | TOK_DELETE[tk1] top_opt TOK_FROM[key] from_list where_opt {
             sqli_store_data(ctx, &$tk1);
             sqli_store_data(ctx, &$key);
+        }
+        ;
+
+call: TOK_CALL[tk] func {
+            sqli_store_data(ctx, &$tk);
         }
         ;
 

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -564,6 +564,21 @@ Tsqli_delete(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_call(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("call func()"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 int
 main(void)
 {
@@ -602,6 +617,7 @@ main(void)
         {"string", Tsqli_string},
         {"use", Tsqli_use},
         {"delete", Tsqli_delete},
+        {"call", Tsqli_call},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Adding CALL as statement in grammar

```
CALL sp_name([parameter[,...]])
CALL sp_name[()]
```
(MySQL, Oracle)