### PR TITLE
DECLARE CURSOR statement

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -601,6 +601,9 @@ sqli_get_token(
       <INITIAL> 'QUICK'/key_end {
           KEYNAME_SET_RET(ctx, arg, QUICK, SQLI_KEY_INSTR);
       }
+      <INITIAL> 'CURSOR'/key_end {
+          KEYNAME_SET_RET(ctx, arg, CURSOR, SQLI_KEY_INSTR);
+      }
       <INITIAL> opchar => OPERATOR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -61,6 +61,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token <data> TOK_TABLE
 %token <data> TOK_USE
 %token <data> TOK_IGNORE TOK_LOW_PRIORITY TOK_QUICK
+%token <data> TOK_CURSOR
 %token TOK_FUNC
 %token TOK_ERROR
 
@@ -655,6 +656,12 @@ declare: TOK_DECLARE[tk] var_list as_opt data_name[type] {
             YYUSE($u1);
             sqli_store_data(ctx, &$len);
             YYUSE($u2);
+        }
+        | TOK_DECLARE[tk1] data_name[name] TOK_CURSOR[tk2] TOK_FOR[tk3] select_parens {
+            sqli_store_data(ctx, &$tk1);
+            sqli_store_data(ctx, &$name);
+            sqli_store_data(ctx, &$tk2);
+            sqli_store_data(ctx, &$tk3);
         }
         ;
 

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -431,6 +431,13 @@ Tsqli_declare(void)
                           true), 0);
     CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
     CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+          detect_add_data(detect,
+                          STR_LEN_ARGS("1; DECLARE name CURSOR FOR select 1"),
+                          true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 


### PR DESCRIPTION
Adding DECLARE CURSOR as statement in grammar
```
DECLARE cursor_name CURSOR FOR select_statement
```
(MySQL)