### PR TITLE
INSERT statement

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -601,6 +601,9 @@ sqli_get_token(
       <INITIAL> 'QUICK'/key_end {
           KEYNAME_SET_RET(ctx, arg, QUICK, SQLI_KEY_INSTR);
       }
+      <INITIAL> 'VALUES'/key_end {
+          KEYNAME_SET_RET(ctx, arg, VALUES, SQLI_KEY_INSTR);
+      }
       <INITIAL> opchar => OPERATOR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, MAXBUFSIZ);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -61,6 +61,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token <data> TOK_TABLE
 %token <data> TOK_USE
 %token <data> TOK_IGNORE TOK_LOW_PRIORITY TOK_QUICK
+%token <data> TOK_VALUES
 %token TOK_FUNC
 %token TOK_ERROR
 
@@ -130,6 +131,7 @@ sql_no_parens:
         | drop
         | use
         | _delete
+        | insert
         | command error {
             sqli_store_data(ctx, &$command);
             yyclearin;
@@ -733,8 +735,22 @@ _delete:  TOK_DELETE[tk1] delete_modifier_opt TOK_FROM[key] from_list where_opt 
         }
         ;
 
-command:  TOK_INSERT
-        | TOK_ATTACH
+insert:   TOK_INSERT[tk1] TOK_INTO[tk2] colref_exact execute {
+            sqli_store_data(ctx, &$tk1);
+            sqli_store_data(ctx, &$tk2);
+        }
+        | TOK_INSERT[tk1] TOK_INTO[tk2] colref_exact '('[u1] name_list ')'[u2] TOK_VALUES[tk3] '('[u3] func_args_list ')'[u4] {
+            sqli_store_data(ctx, &$tk1);
+            sqli_store_data(ctx, &$tk2);
+            YYUSE($u1);
+            YYUSE($u2);
+            sqli_store_data(ctx, &$tk3);
+            YYUSE($u3);
+            YYUSE($u4);
+        }
+        ;
+
+command:  TOK_ATTACH
         ;
 
 close_multiple_parens: ')'[u1] {YYUSE($u1);}

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -564,6 +564,28 @@ Tsqli_delete(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_insert(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("INSERT INTO table_name EXEC "
+                                             "xp_cmdshell 'dir'"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("INSERT INTO table_name (col) "
+                                             "VALUES (1)"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 int
 main(void)
 {
@@ -602,6 +624,7 @@ main(void)
         {"string", Tsqli_string},
         {"use", Tsqli_use},
         {"delete", Tsqli_delete},
+        {"insert", Tsqli_insert},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Adding INSERT as statement in grammar
```
INSERT
    INTO tbl_name
    [(col_name [, col_name] ...)]
    VALUES (value_list)
```
(MySQL)
```
INSERT   
    [ INTO ]  <object>    
    {  
        { VALUES ( expression [ ,...n ] )  
        | execute_statement  
        }  
    }  
}
(SQL Server)