### PR TITLE
Whitespaces

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -662,7 +662,13 @@ sqli_get_token(
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
           goto sqli_VAR;
       }
-      <INITIAL> [\x00] { return (0); }
+      <INITIAL> [\x00] {
+          if (ctx->lexer.re2c.fin && ctx->lexer.re2c.tmp_data_in_use &&
+              ctx->lexer.re2c.pos >= ctx->lexer.re2c.tmp_data + ctx->lexer.re2c.tmp_data_siz) {
+              return (0);
+          }
+          goto yy0;
+      }
       <INITIAL> [^] {
           RET(ctx, TOK_ERROR);
       }

--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -95,7 +95,7 @@ sqli_get_token(
       re2c:condprefix      = sqli_;
       re2c:condenumprefix  = sqli_;
 
-      whitespace = [ \t\v\b\r\n\f\xA0]|[\xC2][\xA0];
+      whitespace = [ \x01-\x1F\x7F\x80\x81\x88\x8D\x8F\x90\x98\x9D\xA0]|[\xC2][\xA0];
       self = [,\.()\[\];=];
       opchar = [~!^&|?%:+\-*/<>];
       opchar_nocomment = [~!^&|?%+<>=];

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -222,6 +222,11 @@ Tsqli_whitespace(void)
         detect_add_data(detect, STR_LEN_ARGS("1\u00A0or\u00A01"), true), 0);
     CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
     CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("1\000or\0001"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 


### PR DESCRIPTION
Adding all whitespaces
```
SQLite3:
0A, 0D, 0C, 09, 20 
MySQL 5:
09, 0A, 0B, 0C, 0D, A0, 20 
MySQL 3:
01, 02, 03, 04, 05, 06, 07, 08, 09, 0A, 0B, 
0C, 0D, 0E, 0F, 10, 11, 12, 13, 14, 15, 16, 
17, 18, 19, 1A, 1B, 1C, 1D, 1E, 1F, 20, 7F, 
80, 81, 88, 8D, 8F, 90, 98, 9D, A0 
PostgreSQL:
0A, 0D, 0C, 09, 20 
Oracle 11g :
00, 0A, 0D, 0C, 09, 20 
MSSQL:
01, 02, 03, 04, 05, 06, 07, 08, 09, 0A, 0B, 
0C, 0D, 0E, 0F, 10, 11, 12, 13, 14, 15, 16, 
17, 18, 19, 1A, 1B, 1C, 1D, 1E, 1F, 20
```
https://media.blackhat.com/us-13/US-13-Salgado-SQLi-Optimization-and-Obfuscation-Techniques-Slides.pdf