### PR TITLE
UFT-8 and `#` in variables

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -216,7 +216,7 @@ sqli_get_token(
           YYSETSTATE(-1);
           RET_DATA(DATA, ctx, arg);
       }
-      <VAR> [0-9a-zA-Z_@$] {
+      <VAR> [0-9a-zA-Z_@$]|[\xC0-\xDF][\x80-\xBF] {
           if (!detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
               DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
               goto sqli_VAR;
@@ -657,7 +657,7 @@ sqli_get_token(
           arg->data.tok = DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1];
           RET(ctx, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
       }
-      <INITIAL> [a-zA-Z_@$] => VAR {
+      <INITIAL> [a-zA-Z_@$]|[\xC0-\xDF][\x80-\xBF] => VAR {
           detect_buf_init(&ctx->lexer.buf, MINBUFSIZ, 256);
           detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1]);
           goto sqli_VAR;

--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -216,7 +216,7 @@ sqli_get_token(
           YYSETSTATE(-1);
           RET_DATA(DATA, ctx, arg);
       }
-      <VAR> [0-9a-zA-Z_@$]|[\xC0-\xDF][\x80-\xBF] {
+      <VAR> [0-9a-zA-Z_@$#]|[\xC0-\xDF][\x80-\xBF] {
           if (!detect_buf_add_char(&ctx->lexer.buf, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
               DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
               goto sqli_VAR;

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -564,6 +564,21 @@ Tsqli_delete(void)
     CU_ASSERT_EQUAL(detect_close(detect), 0);
 }
 
+static void
+Tsqli_var(void)
+{
+    struct detect *detect;
+    uint32_t attack_types;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(detect = detect_open("sqli"));
+    CU_ASSERT_EQUAL(detect_start(detect), 0);
+    CU_ASSERT_EQUAL(
+        detect_add_data(detect, STR_LEN_ARGS("SELECT привет#"), true), 0);
+    CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types), 1);
+    CU_ASSERT_EQUAL(detect_stop(detect), 0);
+    CU_ASSERT_EQUAL(detect_close(detect), 0);
+}
+
 int
 main(void)
 {
@@ -602,6 +617,7 @@ main(void)
         {"string", Tsqli_string},
         {"use", Tsqli_use},
         {"delete", Tsqli_delete},
+        {"var", Tsqli_var},
         CU_TEST_INFO_NULL
     };
     CU_SuiteInfo suites[] = {


### PR DESCRIPTION
Added double byte utf-8 characters and `#` to valid characters for variables