### PR TITLE
Move detecting rce from data context to rce context

### DIFF
--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -93,7 +93,7 @@ context:  start_data
         ;
 
 start_data: TOK_START_DATA data_cont
-        | TOK_START_DATA expr post_exprs_opt ','[u1] data_cont {
+        | TOK_START_DATA expr ','[u1] data_cont {
             YYUSE($u1);
         }
         ;
@@ -147,8 +147,8 @@ data_name:  data
         ;
 
 data_cont:
-        | expr post_exprs_opt after_exp_cont_op_noexpr after_exp_cont
-        | expr post_exprs_opt where_opt after_exp_cont_op_noexpr after_exp_cont
+        | expr after_exp_cont_op_noexpr after_exp_cont
+        | expr where_opt after_exp_cont_op_noexpr after_exp_cont
         ;
 
 update: TOK_UPDATE[tk1] colref_exact TOK_SET[tk2] expr_list {
@@ -335,10 +335,6 @@ post_expr:
 post_exprs:
           post_expr
         | post_exprs post_expr
-        ;
-
-post_exprs_opt:
-        | post_exprs
         ;
 
 func_name:  colref_exact

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -305,13 +305,11 @@ expr_common:
         ;
 
 op_expr:  expr_common
-        | '('[tk] select ')'[u1] expr {
-            sqli_store_data(ctx, &$tk);
-            YYUSE($u1);
+        | op_expr important_operator expr {
+            sqli_store_data(ctx, &$important_operator);
         }
-        | '('[tk] expr ')'[u1] expr {
-            sqli_store_data(ctx, &$tk);
-            YYUSE($u1);
+        | op_expr operator expr {
+            YYUSE($operator);
         }
         | op_expr post_exprs
         ;

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -149,7 +149,6 @@ data_name:  data
 data_cont:
         | expr post_exprs_opt after_exp_cont_op_noexpr after_exp_cont
         | expr post_exprs_opt where_opt after_exp_cont_op_noexpr after_exp_cont
-        | after_exp_cont
         ;
 
 update: TOK_UPDATE[tk1] colref_exact TOK_SET[tk2] expr_list {
@@ -1054,6 +1053,7 @@ after_exp_cont:
 
 start_rce_cont: close_multiple_parens_opt semicolons_opt multiple_sqls
         | close_multiple_parens_opt op_expr after_exp_cont
+        | after_exp_cont_op_noexpr close_multiple_parens after_exp_cont
         ;
 
 %%


### PR DESCRIPTION
Move detecting rce from data context to rce context, remove `post_exprs_opt` after `expr` as `expr` has `post_exprs` in gramma and correct `op_expr` (extend for repeating, for exaple `+1+1+1`)