### PR TITLE
fix crash

### DIFF
--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -106,8 +106,13 @@ start_string: TOK_START_STRING {
 data:     TOK_DATA
         | data TOK_DATA {
             if ($1.flags == SQLI_VALUE_NEEDFREE) {
-                $$.value.str = realloc($1.value.str, $1.value.len +
-                                       $2.value.len);
+                if ($1.value.len + $2.value.len) {
+                    $$.value.str = realloc($1.value.str, $1.value.len +
+                                           $2.value.len);
+                } else {
+                    $$ = $1;
+                }
+
                 if ($$.value.str) {
                     $1.flags = 0;
                 }

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -513,6 +513,12 @@ Tsqli_data_name(void)
 }
 
 static void
+Tsqli_regress_zero_realloc(void)
+{
+    s_sqli_not_attacks({CSTR_LEN("\"''\"")});
+}
+
+static void
 Tbash_constraints(void)
 {
     CU_ASSERT_EQUAL(bash_lexer_test(), 0);
@@ -716,6 +722,7 @@ main(void)
         {"dot_e_dot", Tsqli_dot_e_dot},
         {"label", Tsqli_label},
         {"data_name", Tsqli_data_name},
+        {"regress_zero_realloc", Tsqli_regress_zero_realloc},
         CU_TEST_INFO_NULL
     };
     CU_TestInfo bash_tests[] = {


### PR DESCRIPTION
If `new_size` is zero in `realloc()`, the behavior is implementation defined: null pointer may be returned (in which case the old memory block may or may not be freed) or some non-null pointer may be returned that may not be used to access storage.
Free pointer after calling `realloc()` with new_size equal to zero crash in my implementation.

Example:
```
#include <stdlib.h>

int main()
{
	void *p1, *p2;

	p1 = realloc(NULL, 10);
	p2 = realloc(p1, 0);

	if (!p2 && p1)
		free(p1); // crash
	if (p2)
		free(p2);
}
```

Get around this case

