### PR TITLE
ignoring expressions containing `||` as an injection

### DIFF
--- a/lib/sqli/sqli_lexer.re2c
+++ b/lib/sqli/sqli_lexer.re2c
@@ -672,7 +672,7 @@ sqli_get_token(
           KEYNAME_SET_RET(ctx, arg, TIME, SQLI_KEY_INSTR);
       }
       <INITIAL> '||' {
-          KEYNAME_SET_RET(ctx, arg, OR, SQLI_KEY_INSTR);
+          KEYNAME_SET_RET(ctx, arg, OR2, SQLI_KEY_INSTR);
       }
       <INITIAL> 'AND'/key_end {
           KEYNAME_SET_RET(ctx, arg, AND, SQLI_KEY_INSTR);

--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -34,7 +34,7 @@ sqli_parser_error(struct sqli_detect_ctx *ctx, const char *s)
 %token <data> TOK_DISTINCT TOK_VARIADIC
 %token <data> TOK_DATA TOK_NAME TOK_OPERATOR TOK_NUM
 %token <data> '.' ',' '(' ')' '*' '[' ']' ';' '=' ':' '{' '}' '-' '+'
-%token <data> TOK_OR TOK_AND TOK_IS TOK_NOT TOK_DIV
+%token <data> TOK_OR TOK_OR2 TOK_AND TOK_IS TOK_NOT TOK_DIV
               TOK_MOD TOK_XOR TOK_REGEXP
               TOK_BINARY TOK_SOUNDS TOK_OUTFILE TOK_MATCH TOK_AGAINST TOK_EXIST
 %token <data> TOK_COLLATE TOK_UESCAPE
@@ -266,6 +266,9 @@ within_opt:
 
 logical_expr: noop_expr logical_operator noop_expr {
             sqli_store_data(ctx, &$logical_operator);
+        }
+        | noop_expr TOK_OR2[tk] noop_expr {
+            sqli_token_data_destructor(&$tk);
         }
         | noop_expr '='[operator] noop_expr {
             sqli_token_data_destructor(&$operator);


### PR DESCRIPTION
Example:
```
__v3||366238987||2130614977||\u0411\u0438\u0433\u043B\u0438\u043E\u043D+\u041C\u043E\u0441\u043A\u0432\u0430||1||premium||none||search||no
__v3||625064746||2827439862||\u0431\u0438\u0433\u043B\u0438\u043E\u043D||1||premium||none||search||no
```



