### PR TITLE
processing injection with names after travs and before root dirs

### DIFF
--- a/lib/pt/pt_parser.y
+++ b/lib/pt/pt_parser.y
@@ -54,15 +54,21 @@ sname: TOK_NAME[n] {
 seps:     ssep
         | seps ssep
         ;
-travs:    strav
-        | travs seps strav
-        ;
 inj_pref:
         | inj_pref sroot seps
         | inj_pref sname seps
-        | inj_pref travs seps sname seps
         ;
-inj:    inj_pref travs seps sroot {
+inj_pref2: inj_pref strav seps
+        | inj_pref3 strav seps
+        | inj_pref2 strav seps
+        ;
+inj_pref3: inj_pref2 sname seps
+        | inj_pref3 sname seps
+        ;
+inj:      inj_pref2 sroot {
+            YYACCEPT;
+        }
+        | inj_pref3 sroot {
             YYACCEPT;
         }
         ;

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -18,6 +18,9 @@
 #define s_bash_attacks(...) s_type_checks_("bash", true, __VA_ARGS__)
 #define s_bash_not_attacks(...) s_type_checks_("bash", false, __VA_ARGS__)
 
+#define s_pt_attacks(...) s_type_checks_("pt", true, __VA_ARGS__)
+#define s_pt_not_attacks(...) s_type_checks_("pt", false, __VA_ARGS__)
+
 static void
 s_type_checks(
     const char *typename,
@@ -669,6 +672,14 @@ Tbash_substitute(void)
     );
 }
 
+static void
+Tpt_travs_names_root(void)
+{
+    s_pt_attacks(
+        {CSTR_LEN("../\\windows/\\system32/\\drivers/\\etc/\\hosts")},
+    );
+}
+
 int
 main(void)
 {
@@ -746,11 +757,17 @@ main(void)
         {"substitute", Tbash_substitute},
         CU_TEST_INFO_NULL
     };
+    CU_TestInfo pt_tests[] = {
+        {"travs_names_root", Tpt_travs_names_root},
+        CU_TEST_INFO_NULL
+    };
     CU_SuiteInfo suites[] = {
         {.pName = "generic", .pTests = generic_tests},
         {.pName = "sqli", .pTests = sqli_tests,
          .pInitFunc = s_sqli_suite_init, .pCleanupFunc = s_sqli_suite_deinit},
         {.pName = "bash", .pTests = bash_tests,
+         .pInitFunc = s_sqli_suite_init, .pCleanupFunc = s_sqli_suite_deinit},
+        {.pName = "pt", .pTests = pt_tests,
          .pInitFunc = s_sqli_suite_init, .pCleanupFunc = s_sqli_suite_deinit},
         CU_SUITE_INFO_NULL,
     };


### PR DESCRIPTION
Sample:
`../\windows/\system32/\drivers/\etc/\hosts`