### PR TITLE
Some fixes in variables parsing

### DIFF
--- a/lib/bash/bash.c
+++ b/lib/bash/bash.c
@@ -74,6 +74,7 @@ static void
 bash_lexer_deinit(struct bash_detect_lexer_ctx *lexer)
 {
     detect_buf_deinit(&lexer->buf);
+    detect_buf_deinit(&lexer->var_name);
     detect_re2c_deinit(&lexer->re2c);
 }
 

--- a/lib/bash/bash.c
+++ b/lib/bash/bash.c
@@ -74,6 +74,13 @@ bash_lexer_init(struct bash_detect_lexer_ctx *lexer)
     detect_re2c_init(&lexer->re2c);
     lexer->state = -1;
     RB_INIT(&lexer->vars);
+
+    struct var *var = calloc(1, sizeof(*var));
+    var->name.str = "IFS";
+    var->name.len = 3;
+    var->val.str = " ";
+    var->val.len = 1;
+    RB_INSERT(vars_tree, &lexer->vars, var);
 }
 
 static void

--- a/lib/bash/bash.c
+++ b/lib/bash/bash.c
@@ -2,6 +2,11 @@
 #include <string.h>
 #include <assert.h>
 
+#define VAR2KEY(var) (&(var)->name)
+WRB_GENERATE(
+    vars_tree, var, struct detect_str *,
+    link, detect_str_cmp, VAR2KEY);
+
 static const struct {
     struct detect_ctx_desc desc;
     enum bash_parser_tokentype start_tok;
@@ -68,11 +73,18 @@ bash_lexer_init(struct bash_detect_lexer_ctx *lexer)
     memset(lexer, 0, sizeof(*lexer));
     detect_re2c_init(&lexer->re2c);
     lexer->state = -1;
+    RB_INIT(&lexer->vars);
 }
 
 static void
 bash_lexer_deinit(struct bash_detect_lexer_ctx *lexer)
 {
+    struct detect_parser_info *v, *v_tmp;
+
+    WRB_FOREACH_PDFS(v, vars_tree, &lexer->vars, v_tmp) {
+        free(v);
+    }
+
     detect_buf_deinit(&lexer->buf);
     detect_buf_deinit(&lexer->var_name);
     detect_re2c_deinit(&lexer->re2c);

--- a/lib/bash/bash.h
+++ b/lib/bash/bash.h
@@ -29,6 +29,7 @@ struct bash_detect_lexer_ctx {
     int state;
     int condition;
     struct detect_buf buf;
+    struct detect_buf var_name;
 };
 
 #include "bash_parser.h"

--- a/lib/bash/bash.h
+++ b/lib/bash/bash.h
@@ -22,6 +22,16 @@ struct bash_token_arg_data {
     int tok;
 };
 
+struct var {
+    struct detect_str name;
+    struct detect_str val;
+
+    RB_ENTRY(var) link;
+};
+
+RB_HEAD(vars_tree, var);
+WRB_PROTOTYPE(vars_tree, var, struct detect_str *);
+
 struct bash_detect_lexer_ctx {
     unsigned inword:1;
 
@@ -30,6 +40,7 @@ struct bash_detect_lexer_ctx {
     int condition;
     struct detect_buf buf;
     struct detect_buf var_name;
+    struct vars_tree vars;
 };
 
 #include "bash_parser.h"

--- a/lib/bash/bash_lexer.re2c
+++ b/lib/bash/bash_lexer.re2c
@@ -537,13 +537,27 @@ bash_get_token(
       }
       <VAR> [^] => WORD {
           DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)--;
-          detect_buf_deinit(&ctx->lexer.var_name);
-          goto bash_WORD;
+
+var:
+          {
+              struct var *var;
+              if ((var = WRB_FIND(vars_tree, &ctx->lexer.vars, &ctx->lexer.var_name)) != NULL) {
+                  for(int i = 0; i < var->val.len; ++i) {
+                      if (detect_buf_add_char(&ctx->lexer.buf, var->val.str[i])) {
+                          detect_buf_deinit(&ctx->lexer.var_name);
+                          detect_buf_deinit(&ctx->lexer.buf);
+                          RET(ctx, TOK_ERROR);
+                      }
+                  }
+              }
+
+              detect_buf_deinit(&ctx->lexer.var_name);
+              goto bash_WORD;
+          }
       }
       <VAR2> "}" => WORD {
           DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
-          detect_buf_deinit(&ctx->lexer.var_name);
-          goto bash_WORD;
+          goto var;
       }
       <VAR2> word {
           if (!detect_buf_add_char(&ctx->lexer.var_name, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
@@ -653,7 +667,22 @@ bash_get_token(
 
 return_word:
           {
-              if (memchr(ctx->lexer.buf.data.str, '=', ctx->lexer.buf.data.len)) {
+              char *pch = memchr(ctx->lexer.buf.data.str, '=', ctx->lexer.buf.data.len);
+              if (pch) {
+                  struct var *var = calloc(1, sizeof(*var) + ctx->lexer.buf.data.len - 1 /* '=' */ + 2 /* '\0' */);
+
+                  var->name.str = (void *)(var + 1);
+                  memcpy(var->name.str, ctx->lexer.buf.data.str, pch - ctx->lexer.buf.data.str);
+                  var->name.len = pch - ctx->lexer.buf.data.str;
+                  var->name.str[var->name.len] = 0;
+
+                  var->val.str = (void *)((char *)(var + 1) + (pch - ctx->lexer.buf.data.str + 1));
+                  memcpy(var->val.str, pch + 1, ctx->lexer.buf.data.str + ctx->lexer.buf.data.len - pch - 1);
+                  var->val.len = ctx->lexer.buf.data.str + ctx->lexer.buf.data.len - pch - 1;
+                  var->val.str[var->val.len] = 0;
+
+                  RB_INSERT(vars_tree, &ctx->lexer.vars, var);
+
                   detect_buf_deinit(&ctx->lexer.buf);
                   KEYNAME_SET_RET_WO_CHECK(ctx, arg, ASSIGNMENT_WORD, 0);
               }

--- a/lib/bash/bash_lexer.re2c
+++ b/lib/bash/bash_lexer.re2c
@@ -543,6 +543,12 @@ var:
               struct var *var;
               if ((var = WRB_FIND(vars_tree, &ctx->lexer.vars, &ctx->lexer.var_name)) != NULL) {
                   for(int i = 0; i < var->val.len; ++i) {
+                      if (memchr(" \t", var->val.str[i], 2)) {
+                          detect_buf_deinit(&ctx->lexer.var_name);
+                          YYSETCONDITION(bash_INITIAL);
+                          YYSETSTATE(-1);
+                          goto return_word;
+                      }
                       if (detect_buf_add_char(&ctx->lexer.buf, var->val.str[i])) {
                           detect_buf_deinit(&ctx->lexer.var_name);
                           detect_buf_deinit(&ctx->lexer.buf);

--- a/lib/bash/bash_lexer.re2c
+++ b/lib/bash/bash_lexer.re2c
@@ -500,30 +500,60 @@ bash_get_token(
       <INITIAL, WORD> [$][_a-zA-Z] => VAR {
           if (!ctx->lexer.buf.data.str)
               detect_buf_init(&ctx->lexer.buf, 32, 1024);
-          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
-          goto bash_VAR;
+
+          detect_buf_init(&ctx->lexer.var_name, 32, 1024);
+          if (!detect_buf_add_char(&ctx->lexer.var_name, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
+              DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+              goto bash_VAR;
+          } else {
+              detect_buf_deinit(&ctx->lexer.var_name);
+              detect_buf_deinit(&ctx->lexer.buf);
+              RET(ctx, TOK_ERROR);
+          }
       }
       <INITIAL, WORD> "${"word => VAR2 {
           if (!ctx->lexer.buf.data.str)
               detect_buf_init(&ctx->lexer.buf, 32, 1024);
-          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
-          goto bash_VAR2;
+
+          detect_buf_init(&ctx->lexer.var_name, 32, 1024);
+          if (!detect_buf_add_char(&ctx->lexer.var_name, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
+              DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+              goto bash_VAR2;
+          } else {
+              detect_buf_deinit(&ctx->lexer.var_name);
+              detect_buf_deinit(&ctx->lexer.buf);
+              RET(ctx, TOK_ERROR);
+          }
       }
       <VAR> [_a-zA-Z0-9] {
-          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
-          goto bash_VAR;
+          if (!detect_buf_add_char(&ctx->lexer.var_name, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
+              DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+              goto bash_VAR;
+          } else {
+              detect_buf_deinit(&ctx->lexer.var_name);
+              detect_buf_deinit(&ctx->lexer.buf);
+              RET(ctx, TOK_ERROR);
+          }
       }
       <VAR> [^] => WORD {
           DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)--;
+          detect_buf_deinit(&ctx->lexer.var_name);
           goto bash_WORD;
       }
       <VAR2> "}" => WORD {
           DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          detect_buf_deinit(&ctx->lexer.var_name);
           goto bash_WORD;
       }
       <VAR2> word {
-          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
-          goto bash_VAR2;
+          if (!detect_buf_add_char(&ctx->lexer.var_name, DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1])) {
+              DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+              goto bash_VAR2;
+          } else {
+              detect_buf_deinit(&ctx->lexer.var_name);
+              detect_buf_deinit(&ctx->lexer.buf);
+              RET(ctx, TOK_ERROR);
+          }
       }
       <WORD> word {
           if (DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1] == '\'') {

--- a/lib/bash/bash_lexer.re2c
+++ b/lib/bash/bash_lexer.re2c
@@ -491,9 +491,39 @@ bash_get_token(
           YYSETSTATE(-1);
           goto return_word;
       }
-      <WORD> [$][_a-zA-Z][_a-zA-Z0-9]*|[$][0-9]|"${"word+"}" {
+      <INITIAL, WORD> [$][0-9\-\*@!] {
+          if (!ctx->lexer.buf.data.str)
+              detect_buf_init(&ctx->lexer.buf, 32, 1024);
           DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
           goto bash_WORD;
+      }
+      <INITIAL, WORD> [$][_a-zA-Z] => VAR {
+          if (!ctx->lexer.buf.data.str)
+              detect_buf_init(&ctx->lexer.buf, 32, 1024);
+          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          goto bash_VAR;
+      }
+      <INITIAL, WORD> "${"word => VAR2 {
+          if (!ctx->lexer.buf.data.str)
+              detect_buf_init(&ctx->lexer.buf, 32, 1024);
+          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          goto bash_VAR2;
+      }
+      <VAR> [_a-zA-Z0-9] {
+          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          goto bash_VAR;
+      }
+      <VAR> [^] => WORD {
+          DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)--;
+          goto bash_WORD;
+      }
+      <VAR2> "}" => WORD {
+          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          goto bash_WORD;
+      }
+      <VAR2> word {
+          DETECT_RE2C_UNUSED_BEFORE(&ctx->lexer.re2c);
+          goto bash_VAR2;
       }
       <WORD> word {
           if (DETECT_RE2C_YYCURSOR(&ctx->lexer.re2c)[-1] == '\'') {
@@ -856,13 +886,6 @@ return_word:
       <INITIAL> "{"[_a-zA-Z][_a-zA-Z0-9]*"}"/[<>] {
           YYSETSTATE(-1);
           KEYNAME_SET_RET_WO_CHECK(ctx, arg, REDIR_WORD, 0);
-      }
-      <INITIAL> [$][_a-zA-Z][_a-zA-Z0-9]*|[$][0-9]|"${"word+"}" {
-          YYSETSTATE(-1);
-          if (ctx->last_read_token != TOK_WORD)
-              KEYNAME_SET_RET_WO_CHECK(ctx, arg, WORD, BASH_KEY_INSTR);
-          else
-              KEYNAME_SET_RET_WO_CHECK(ctx, arg, WORD, 0);
       }
       <INITIAL> word {
           detect_buf_init(&ctx->lexer.buf, 32, 1024);

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -548,6 +548,7 @@ Tbash_simplest(void)
         {CSTR_LEN("$-id")},
         {CSTR_LEN("$*id")},
         {CSTR_LEN("(aa=d;i$aa)")},
+        {CSTR_LEN("cat$IFS/etc/os-release")},
     );
 }
 

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -547,6 +547,7 @@ Tbash_simplest(void)
         {CSTR_LEN("VAR=VAL l${name}s")},
         {CSTR_LEN("$-id")},
         {CSTR_LEN("$*id")},
+        {CSTR_LEN("(aa=d;i$aa)")},
     );
 }
 

--- a/lib/test/detect_unit.c
+++ b/lib/test/detect_unit.c
@@ -545,6 +545,8 @@ Tbash_simplest(void)
         {CSTR_LEN("VAR=VAL l$1s")},
         {CSTR_LEN("VAR=VAL l$name's'")},
         {CSTR_LEN("VAR=VAL l${name}s")},
+        {CSTR_LEN("$-id")},
+        {CSTR_LEN("$*id")},
     );
 }
 


### PR DESCRIPTION
- variables parsing refactoring
- ignore the variable name as command (a lot of false positives)
- add the parse of standard variables (`$ -`, `$ *`, `$ @`)
- saving and pasting variable values (`a|(aa=d;i$aa)`)
- add var $IFS as predefined