### PR TITLE
Revert "Detect incorrect injections with expr after `PROCEDURE ANALYSE(...)`."

### DIFF
--- a/lib/sqli/sqli_parser.y
+++ b/lib/sqli/sqli_parser.y
@@ -756,7 +756,7 @@ select_extras_opt:
         ;
 
 procedure:
-          TOK_PROCEDURE[tk1] func expr {
+          TOK_PROCEDURE[tk1] func {
             sqli_store_data(ctx, &$tk1);
         }
         ;


### PR DESCRIPTION
Reverts wallarm/libdetection#101 cause of failed tests:
```
  Test: procedure_analyse ...FAILED
    1. /home/ubuntu/git/libdetection-gh/lib/test/detect_unit.c:38  - CU_ASSERT_EQUAL(detect_has_attack(detect, &attack_types),has_attack)
```